### PR TITLE
fix: security hardening and code quality improvements

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,54 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Flask web app for browsing, uploading, downloading, and deleting files from OpenShift PersistentVolumeClaims (PVCs). Primary use case: viewing `compliance-operator` scan results from OCP4 in HTML format via `oscap xccdf generate report`. Also usable as a general PVC file browser.
+
+## Development Commands
+
+```bash
+# Install dependencies
+pip install -r requirements.txt
+
+# Run locally (port 5123)
+SAVEPASS=yourpassword python app.py
+
+# Run with gunicorn (production-like)
+SAVEPASS=yourpassword gunicorn -b 0.0.0.0:5123 --log-level debug app:app
+
+# Build container image
+docker build -f dockerfile -t py-upload-download .
+```
+
+No test suite exists. No linter configured.
+
+## Architecture
+
+Single-file Flask app (`app.py`) — all routes, auth, and file operations in one module.
+
+- **Auth**: password-only login via `SAVEPASS` env var, bcrypt-hashed comparison, Flask session-based
+- **File storage**: serves from `UPLOAD_FOLDER` env var (default: `./data`), supports nested directory browsing
+- **XCCDF conversion**: `.bzip2` files get a "Convert" button that shells out to `oscap xccdf generate report` (requires `openscap-scanner` installed — handled in Dockerfile via `yum`)
+- **Templates**: `templates/index.html` (file browser) and `templates/login.html` (login form), plain HTML with Jinja2
+
+## Environment Variables
+
+| Variable | Purpose | Default |
+|----------|---------|---------|
+| `SAVEPASS` | Login password (required) | None |
+| `UPLOAD_FOLDER` | Root directory to browse/upload | `data` |
+
+## CI/CD
+
+GitHub Actions (`.github/workflows/ci.yaml`): builds Docker image, pushes to Quay.io, signs with Cosign. Triggers on push to `main` and `feature/**` branches. Feature branches get `-feature` tag suffix.
+
+## Deployment
+
+Example OpenShift manifests in `example_deployment/`:
+- `deployment_compliance_get_result_example.yaml` — mounts compliance PVCs (ocp4-cis, worker, master)
+- `deployment_other_purpose.yaml` — generic PVC browsing (replace `replac-me-pvc-name`)
+- `service.yaml` and `route.yaml` — OpenShift Service/Route
+
+Container runs as non-root (UID 1001) on UBI9 Python 3.12 base image.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,7 @@ Single-file Flask app (`app.py`) — all routes, auth, and file operations in on
 - **Auth**: password-only login via `SAVEPASS` env var, bcrypt-hashed comparison, Flask session-based
 - **File storage**: serves from `UPLOAD_FOLDER` env var (default: `./data`), supports nested directory browsing
 - **XCCDF conversion**: `.bzip2` files get a "Convert" button that shells out to `oscap xccdf generate report` (requires `openscap-scanner` installed — handled in Dockerfile via `yum`)
+- **Upload limit**: 100MB max via `MAX_CONTENT_LENGTH`
 - **Templates**: `templates/index.html` (file browser) and `templates/login.html` (login form), plain HTML with Jinja2
 
 ## Environment Variables
@@ -39,6 +40,7 @@ Single-file Flask app (`app.py`) — all routes, auth, and file operations in on
 |----------|---------|---------|
 | `SAVEPASS` | Login password (required) | None |
 | `UPLOAD_FOLDER` | Root directory to browse/upload | `data` |
+| `SECRET_KEY` | Flask session signing key | Random bytes (sessions lost on restart) |
 
 ## CI/CD
 

--- a/app.py
+++ b/app.py
@@ -15,6 +15,7 @@ if not SAVE_PASS:
     print("Error: SAVEPASS environment variable is required", file=sys.stderr)
     sys.exit(1)
 PASS_HASH = bcrypt.generate_password_hash(SAVE_PASS)
+del SAVE_PASS
 app.config['UPLOAD_FOLDER'] = UPLOAD_FOLDER
 app.config['MAX_CONTENT_LENGTH'] = 100 * 1024 * 1024
 app.secret_key = os.getenv('SECRET_KEY', os.urandom(24))
@@ -127,11 +128,11 @@ def logout():
 @login_required
 def delete_file(filepath):
     file_path = safe_path(app.config['UPLOAD_FOLDER'], filepath)
-    if os.path.exists(file_path):
+    if os.path.isfile(file_path):
         os.remove(file_path)
         flash("File deleted successfully")
     else:
-        flash("File not found")
+        flash("File not found or is a directory")
     directory = os.path.dirname(filepath)
     return redirect(url_for('index', subpath=directory))
 

--- a/app.py
+++ b/app.py
@@ -1,8 +1,9 @@
-from flask import Flask, request, send_from_directory, render_template, redirect, url_for, flash, session, jsonify
-from flask import Flask, request, send_from_directory, render_template, redirect, url_for, flash, session
+from flask import Flask, request, send_from_directory, render_template, redirect, url_for, flash, session, abort
 from flask_bcrypt import Bcrypt
+from werkzeug.utils import secure_filename
 from functools import wraps
 import os
+import sys
 import subprocess
 from datetime import datetime
 
@@ -10,9 +11,20 @@ app = Flask(__name__)
 bcrypt = Bcrypt(app)
 UPLOAD_FOLDER = os.getenv('UPLOAD_FOLDER', 'data')
 SAVE_PASS = os.getenv('SAVEPASS')
+if not SAVE_PASS:
+    print("Error: SAVEPASS environment variable is required", file=sys.stderr)
+    sys.exit(1)
+PASS_HASH = bcrypt.generate_password_hash(SAVE_PASS)
 app.config['UPLOAD_FOLDER'] = UPLOAD_FOLDER
-app.secret_key = 'supersecretkey'
+app.config['MAX_CONTENT_LENGTH'] = 100 * 1024 * 1024
+app.secret_key = os.getenv('SECRET_KEY', os.urandom(24))
 os.makedirs(UPLOAD_FOLDER, exist_ok=True)
+
+def safe_path(base, user_path):
+    full = os.path.realpath(os.path.join(base, user_path))
+    if not full.startswith(os.path.realpath(base) + os.sep) and full != os.path.realpath(base):
+        abort(403)
+    return full
 
 def login_required(f):
     @wraps(f)
@@ -26,7 +38,7 @@ def login_required(f):
 @app.route('/<path:subpath>')
 @login_required
 def index(subpath=''):
-    current_path = os.path.join(app.config['UPLOAD_FOLDER'], subpath)
+    current_path = safe_path(app.config['UPLOAD_FOLDER'], subpath)
     if not os.path.exists(current_path):
         flash("Directory not found")
         return redirect(url_for('index'))
@@ -72,7 +84,12 @@ def upload_file():
         flash("No selected file")
         return redirect(url_for('index', subpath=current_path))
 
-    upload_path = os.path.join(app.config['UPLOAD_FOLDER'], current_path, file.filename)
+    safe_dir = safe_path(app.config['UPLOAD_FOLDER'], current_path)
+    filename = secure_filename(file.filename)
+    if not filename:
+        flash("Invalid filename")
+        return redirect(url_for('index', subpath=current_path))
+    upload_path = os.path.join(safe_dir, filename)
     os.makedirs(os.path.dirname(upload_path), exist_ok=True)
     file.save(upload_path)
     flash("File uploaded successfully")
@@ -81,11 +98,10 @@ def upload_file():
 @app.route('/download/<path:filepath>')
 @login_required
 def download_file(filepath):
-    directory = os.path.dirname(filepath)
-    filename = os.path.basename(filepath)
+    full_path = safe_path(app.config['UPLOAD_FOLDER'], filepath)
     return send_from_directory(
-        os.path.join(app.config['UPLOAD_FOLDER'], directory),
-        filename,
+        os.path.dirname(full_path),
+        os.path.basename(full_path),
         as_attachment=True
     )
 
@@ -93,7 +109,7 @@ def download_file(filepath):
 def login():
     if request.method == 'POST':
         password = request.form['password']
-        if bcrypt.check_password_hash(bcrypt.generate_password_hash(SAVE_PASS), password):
+        if bcrypt.check_password_hash(PASS_HASH, password):
             session['logged_in'] = True
             return redirect(url_for('index'))
         else:
@@ -110,7 +126,7 @@ def logout():
 @app.route('/delete/<path:filepath>', methods=['POST'])
 @login_required
 def delete_file(filepath):
-    file_path = os.path.join(app.config['UPLOAD_FOLDER'], filepath)
+    file_path = safe_path(app.config['UPLOAD_FOLDER'], filepath)
     if os.path.exists(file_path):
         os.remove(file_path)
         flash("File deleted successfully")
@@ -122,12 +138,13 @@ def delete_file(filepath):
 @app.route('/convert/<path:filepath>', methods=['POST'])
 @login_required
 def convert_to_html(filepath):
-    file_path = os.path.join(app.config['UPLOAD_FOLDER'], filepath)
+    file_path = safe_path(app.config['UPLOAD_FOLDER'], filepath)
     if os.path.exists(file_path):
         html_file = f"{file_path}.html"
         try:
-            subprocess.run(['oscap', 'xccdf', 'generate', 'report', file_path],
-                           check=True, stdout=open(html_file, 'w'))
+            with open(html_file, 'w') as f:
+                subprocess.run(['oscap', 'xccdf', 'generate', 'report', file_path],
+                               check=True, stdout=f)
             flash("File converted successfully")
         except subprocess.CalledProcessError:
             flash("Error in converting the file")

--- a/templates/login.html
+++ b/templates/login.html
@@ -23,3 +23,4 @@
       {% endif %}
     {% endwith %}
 </body>
+</html>


### PR DESCRIPTION
## Summary
- Fix **path traversal vulnerability** in all file routes via `safe_path()` realpath validation — previously users could escape `UPLOAD_FOLDER` with `../`
- Remove **hardcoded Flask secret key** (`'supersecretkey'`) — now uses `SECRET_KEY` env var or random bytes
- **Sanitize uploaded filenames** with `werkzeug.utils.secure_filename()`
- **Hash password once at startup** instead of re-hashing every login (~100ms saved per attempt)
- Add **SAVEPASS env var guard** — exits with clear error instead of cryptic bcrypt crash
- Add **100MB upload size limit** via `MAX_CONTENT_LENGTH`
- Fix **file handle leak** in oscap convert subprocess (use context manager)
- Remove duplicate Flask import line
- Add `CLAUDE.md` for codebase documentation

## Test plan
- [ ] Deploy with `SAVEPASS` and `SECRET_KEY` env vars set
- [ ] Verify login works with correct password
- [ ] Verify login rejects wrong password
- [ ] Browse directories, upload, download, delete files
- [ ] Verify path traversal blocked: `GET /../../../etc/passwd` → 403
- [ ] Verify app refuses to start without `SAVEPASS` set
- [ ] Verify large upload (>100MB) rejected

🤖 Generated with [Claude Code](https://claude.ai/code)